### PR TITLE
feat(trigger): 触发键改为可配置项，默认为分号

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ RIME 输入法辅助码与音形分离插件
 
 ### 环境依赖
 
-已知 Win、Mac 和 Linux 上的 Rime 输入法中，lua 插件默认是开启状态。但如果在执行完**插件安装**后发现无法使用，建议你按照 [Lua-DateTranslator](https://github.com/hchunhui/librime-lua/wiki) 的指引进行测试。测试方法是输入 date，查看候选词中是否能显示当前日期（例如 2023 年 10 月 16 日）。请注意，日期信息可能不会出现在第一页候选词中，你可能需要向后翻页查找。如果日期显示正常，但此插件仍然无法使用，请开设一个 issue 进行反馈。
+已知 Windows、macOS 和 Linux 上的 Rime 输入法中，Lua 插件默认是开启状态。但如果在执行完**插件安装**后发现无法使用，建议你按照 [Lua-DateTranslator](https://github.com/hchunhui/librime-lua/wiki) 的指引进行测试。测试方法是输入 date，查看候选词中是否能显示当前日期（例如 2023 年 10 月 16 日）。请注意，日期信息可能不会出现在第一页候选词中，你可能需要向后翻页查找。如果日期显示正常，但此插件仍然无法使用，请开设一个 issue 进行反馈。
+
+而在 Android 平台上，[同文输入法](https://github.com/osfans/trime) 和 [小企鹅输入法 5](https://github.com/fcitx5-android/fcitx5-android) 都支持 Lua 插件。经过我几天的亲身体验，我更倾向于推荐后者。但需要注意的是，为了支持 Rime 配置，必须安装 [Rime 插件](https://f-droid.org/packages/org.fcitx.fcitx5.android.plugin.rime/)。此外，为确保应用的正常运行，应选择安装 [F-Droid 发行的小企鹅输入法版本](https://f-droid.org/packages/org.fcitx.fcitx5.android/)，而不是 Google Play 上的版本。
+
+#### 如何在小企鹅输入法 5 中启用 Rime 插件
+
+首先打开 App，点击“插件”，加载 Rime 插件并返回。接着，依次操作：点击“输入法” -> 右下角的 “+” 号 -> 选择“中州韵” -> 点击新增行右侧的齿轮图标 -> 进入“用户数据目录”。然后，请确保应用已被授予读写权限。至此，Rime 插件的激活步骤基本完成，接下来的操作与其他平台相同。上述提到的“用户数据目录”即为接下来需要用到的 `Rime 配置文件夹`。
 
 ### 插件安装
 
@@ -47,6 +53,10 @@ RIME 输入法辅助码与音形分离插件
 
       # 允许以 `;` 符号上屏，最后的 `;` 为英文半角字符，非中文全角。前面部分根据个人配置自行调整
       speller/alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA.,;
+
+      # 自定义触发键，注意：请确保所选字符已包含在上述 speller/alphabet 的值中
+      # key_binder/+;
+        # aux_code_trigger: "."
     ```
 
 3. 重新配置 Rime 输入法，如果一切顺利，应该就可以使用了。
@@ -85,4 +95,4 @@ RIME 输入法辅助码与音形分离插件
   源文件采用 GB2312 编码且包含手心拼音需要的冗余首码，此项目中的 txt 文件已转换为 UTF-8 编码并且移除了冗余首码，可直接使用（并提供去冗的 python 脚本）。
 * [@ksqsf](https://github.com/ksqsf) 贡献的词语级筛选功能
 * [@shewer](https://github.com/shewer) 优化的代码以及辅码文件配置
-* [@AiraNadih](https://github.com/AiraNadih) 增加小鹤码表、优化辅码分号逻辑以及润色此说明文档
+* [@AiraNadih](https://github.com/AiraNadih) 增加小鹤码表、优化辅码分号逻辑、触发键改为可配置项，以及润色此说明文档

--- a/lua/aux_code.lua
+++ b/lua/aux_code.lua
@@ -8,18 +8,25 @@ function AuxFilter.init(env)
 
     env.aux_code = AuxFilter.readAuxTxt(env.name_space)
 
+    local engine = env.engine
+    local config = engine.schema.config
+    
+    -- 設定預設觸發鍵為分號，並從配置中讀取自訂的觸發鍵
+    env.trigger_key = config:get_string("key_binder/aux_code_trigger") or ";"
+    
     ----------------------------
     -- 持續選詞上屏，保持分號存在 --
     ----------------------------
-    env.notifier = env.engine.context.select_notifier:connect(function(ctx)
+    env.notifier = engine.context.select_notifier:connect(function(ctx)
         -- 含有輔助碼分隔符才處理，；
-        if not string.find(ctx.input, ';') then
+        if not string.find(ctx.input, env.trigger_key) then
             return
         end
 
         local preedit = ctx:get_preedit()
-        local removeAuxInput = ctx.input:match("([^,]+);")
-        local reeditTextFront = preedit.text:match("([^,]+);")
+        local removeAuxInput = ctx.input:match("([^,]+)" .. env.trigger_key)
+        local reeditTextFront = preedit.text:match("([^,]+)" 
+        .. env.trigger_key)
 
         -- ctx.text 隨著選字的進行，oaoaoa； 有如下的輸出：
         -- ---- 有輔助碼 ----
@@ -39,7 +46,7 @@ function AuxFilter.init(env)
         ctx.input = removeAuxInput
         if reeditTextFront and reeditTextFront:match("[a-z]") then
             -- 給詞尾自動添加分隔符，上面的 re.match 會把分隔符刪掉
-            ctx.input = ctx.input .. ';'
+            ctx.input = ctx.input .. env.trigger_key
         else
             -- 剩下的直接上屏
             ctx:commit()
@@ -163,9 +170,10 @@ function AuxFilter.func(input, env)
 
     -- 分割部分正式開始
     local auxStr = ''
-    if string.find(inputCode, ';') then
+    if string.find(inputCode, env.trigger_key) then
         -- 字符串中包含 ; 分字字符
-        local localSplit = inputCode:match(";([^,]+)")
+        local trigger_pattern = env.trigger_key:gsub("%W", "%%%1")  -- 處理特殊字符
+        local localSplit = inputCode:match(trigger_pattern .. "([^,]+)")
         if localSplit then
             auxStr = string.sub(localSplit, 1, 2)
             -- log.info('re.match ' .. local_split)

--- a/lua/aux_code.lua
+++ b/lua/aux_code.lua
@@ -15,10 +15,10 @@ function AuxFilter.init(env)
     env.trigger_key = config:get_string("key_binder/aux_code_trigger") or ";"
     
     ----------------------------
-    -- 持續選詞上屏，保持分號存在 --
+    -- 持續選詞上屏，保持輔助碼分隔符存在 --
     ----------------------------
     env.notifier = engine.context.select_notifier:connect(function(ctx)
-        -- 含有輔助碼分隔符才處理，；
+        -- 含有輔助碼分隔符才處理
         if not string.find(ctx.input, env.trigger_key) then
             return
         end
@@ -38,11 +38,11 @@ function AuxFilter.init(env)
         -- >>> 啊吖 oa；
         -- >>> 啊吖啊；
         -- 這邊把已經上屏的字段 (preedit:text) 進行分割；
-        -- 如果已經全部選完了，分割後的結果就是 nil，否則都是 啞卡 a 這種字符串
+        -- 如果已經全部選完了，分割後的結果就是 nil，否則都是 吖卡 a 這種字符串
         -- 驗證方式：
         -- log.info('select_notifier', ctx.input, removeAuxInput, preedit.text, reeditTextFront)
 
-        -- 當最終不含有任何字母時 (候選)，就跳出分割模式，並把；符號刪掉
+        -- 當最終不含有任何字母時 (候選)，就跳出分割模式，並把輔助碼分隔符刪掉
         ctx.input = removeAuxInput
         if reeditTextFront and reeditTextFront:match("[a-z]") then
             -- 給詞尾自動添加分隔符，上面的 re.match 會把分隔符刪掉
@@ -171,7 +171,7 @@ function AuxFilter.func(input, env)
     -- 分割部分正式開始
     local auxStr = ''
     if string.find(inputCode, env.trigger_key) then
-        -- 字符串中包含 ; 分字字符
+        -- 字符串中包含輔助碼分隔符
         local trigger_pattern = env.trigger_key:gsub("%W", "%%%1")  -- 處理特殊字符
         local localSplit = inputCode:match(trigger_pattern .. "([^,]+)")
         if localSplit then


### PR DESCRIPTION
最近我不在家，手头只有一部 Android 设备。我在这部设备上尝试了同文输入法和 Fcitx 5 输入法，发现它们都支持 Lua 脚本，而且这个插件在这两种输入法上都能正常运行。

但我遇到了一个小问题。因为手机键盘的布局限制，原本的触发键（分号）使用起来并不方便，这促使我想到了进行相应修改。

这个修改我已经进行了测试并正在使用，不过可能还需要更多的测试来确保稳定性。

另外，由于我目前没有电脑，所以我暂时没有计划更新相关文档。我打算等回到家后再进行文档的更新。

因此，我建议暂时不要合并这个 PR 。