### PR TITLE
enhance: Improve performance and reduce memory consumption

### DIFF
--- a/lua/aux_code.lua
+++ b/lua/aux_code.lua
@@ -64,6 +64,10 @@ end
 -- 閱讀輔碼文件 --
 ----------------
 function AuxFilter.readAuxTxt(txtpath)
+    if AuxFilter.cache then
+        return AuxFilter.cache
+    end
+
     -- log.info("** AuxCode filter", 'read Aux code txt:', txtpath)
 
     local defaultFile = 'ZRM_Aux-code_4.3.txt'
@@ -91,7 +95,8 @@ function AuxFilter.readAuxTxt(txtpath)
     --     log.info(key, table.concat(value, ','))
     -- end
 
-    return auxCodes
+    AuxFilter.cache = auxCodes
+    return AuxFilter.cache
 end
 
 -- local function getUtf8CharLength(byte)


### PR DESCRIPTION
Rime 会在每次创建输入会话时初始化 Lua 组件（比如切换一个输入框就会重新加载一次）。这会导致每个会话初次打字轻微卡顿，也会占用额外内存，造成 GC 压力。通过 memoization 可解决该问题。

当前代码仅仅把表挂在 module 上并不能解决上述问题，因为 `init` 总是会在会话组件初始化时调用（即没有省去读文件、解析并最终 GC 丢弃无用结果的开销）。