### PR TITLE
Optimize aux code table performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ RIME 输入法辅助码与音形分离插件 -> <a href="https://www.bilibili.co
 * [@copperay](https://github.com/copperay) 维护的手心输入法自然码码表 [copperay/ZRM_Aux-code](https://github.com/copperay/ZRM_Aux-code/tree/main)  
   源文件采用 GB2312 编码且包含手心拼音需要的冗余首码，此项目中的 txt 文件已转换为 UTF-8 编码并且移除了冗余首码，可直接使用（并提供去冗的 python 脚本）。
 * [@dykwok](https://github.com/dykwok) 添加的五笔辅助码 (都会五笔了何苦用拼音=_=)，码表来自 [rime/rime-wubi](https://github.com/rime/rime-wubi)
-* [@ksqsf](https://github.com/ksqsf) 贡献的词语级筛选功能
+* [@ksqsf](https://github.com/ksqsf) 贡献的词语级筛选功能及性能优化
 * [@shewer](https://github.com/shewer) 优化的代码以及辅码文件配置
 * [@AiraNadih](https://github.com/AiraNadih) 增加小鹤码表、优化辅码分号逻辑、触发键改为可配置项，以及润色此说明文档
 * [@expoli](https://github.com/expoli) 对文档说明的修改

--- a/lua/aux_code.lua
+++ b/lua/aux_code.lua
@@ -85,8 +85,11 @@ function AuxFilter.readAuxTxt(txtpath)
         line = line:match("[^\r\n]+") -- 去掉換行符，不然 value 是帶著 \n 的
         local key, value = line:match("([^=]+)=(.+)") -- 分割 = 左右的變數
         if key and value then
-            auxCodes[key] = auxCodes[key] or {}
-            table.insert(auxCodes[key], value)
+            if auxCodes[key] then
+                auxCodes[key] = auxCodes[key] .. " " .. value
+            else
+                auxCodes[key] = value
+            end
         end
     end
     file:close()
@@ -148,7 +151,7 @@ function AuxFilter.fullAux(env, word)
         local char = utf8.char(codePoint)
         local charAuxCodes = AuxFilter.aux_code[char] -- 每個字的輔助碼組
         if charAuxCodes then -- 輔助碼存在
-            for _, code in ipairs(charAuxCodes) do
+            for code in charAuxCodes:gmatch("%S+") do
                 for i = 1, #code do
                     fullAuxCodes[i] = fullAuxCodes[i] or {}
                     fullAuxCodes[i][code:sub(i, i)] = true
@@ -228,7 +231,7 @@ function AuxFilter.func(input, env)
 
             -- 給待選項加上輔助碼提示
             if env.show_aux_notice and auxCodes and #auxCodes > 0 then
-                local codeComment = table.concat(auxCodes, ',')
+                local codeComment = auxCodes:gsub(' ', ',')
                 -- 處理 simplifier
                 if cand:get_dynamic_type() == "Shadow" then
                     local shadowText = cand.text
@@ -271,3 +274,7 @@ function AuxFilter.fini(env)
 end
 
 return AuxFilter
+
+-- Local Variables:
+-- lua-indent-level: 4
+-- End:


### PR DESCRIPTION
原辅码表使用 `map<char,list>` 格式。这种格式对 GC 来说不太友好，而新版 librime-lua 会在每次翻译时都执行一次 full GC，造成较大的延迟。

本 PR 将数据结构改为 `map<char,str>` ，使用时 `gmatch` 遍历字符串中的每个辅码编码。

实际使用表明，该法可显著降低延迟。（不过本项目是间接辅助码，可能对查询延迟的要求不高，所以其实也不太需要这个优化？ =_=）